### PR TITLE
meson: declare libkmod as required_tools instead of required_test

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -128,7 +128,7 @@ if with_tools != 'no'
         required_tools = true
     endif
 
-    dep_kmod = dependency('libkmod', version: '>= 24', required: required_test)
+    dep_kmod = dependency('libkmod', version: '>= 24', required: required_tools)
 
     if dep_kmod.found()
         enable_tools = true


### PR DESCRIPTION
even with -Dwith-tools=yes there is no warning (it just rolls along with tools set to no) that there isn't libkmod available, this should fix it.