### PR TITLE
Downgrade check to require a minimum of v0.11.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -103,7 +103,7 @@ if with_tests != 'no'
         required_test = true
     endif
 
-    dep_check = dependency('check', version: '>= 0.12.0', required: required_test)
+    dep_check = dependency('check', version: '>= 0.11.0', required: required_test)
     dep_umockdev = dependency('umockdev-1.0', version: '>= 0.9.0', required: required_test)
     run_umockdev = find_program('umockdev-wrapper', required: required_test)
 


### PR DESCRIPTION
The latest version of check does not appear to be required, and downgrading the requirement for `check` to require at least v0.11.0 allows Linux Driver Management tests to be built in current stable releases of Fedora.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>