### PR TITLE
Allow versions of libusb-1.0 newer than 1.0.21 to satisfy the dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -93,7 +93,7 @@ config_h = configure_file(
 config_h_dir = include_directories('.')
 
 # Required dependencies
-dep_usb = dependency('libusb-1.0', version: '1.0.21')
+dep_usb = dependency('libusb-1.0', version: '>= 1.0.21')
 
 glib_min_version = '>= 2.54.0'
 dep_glib2 = dependency('glib-2.0', version: glib_min_version)


### PR DESCRIPTION
The `libusb-1.0` dependency was set to exactly require 1.0.21, which breaks the build when trying to build against 1.0.22.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>